### PR TITLE
 Support for 1.x and 2.x+ MSS110 hardware versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 yarn-error.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -17,12 +17,18 @@ meross plugin:
 
 - `npm i -g homebridge-meross-plug` (You may need `sudo` depending on
   your homebridge setup)
-- Edit your `config.json` to include the plug `name`, `channel`, &
-  `deviceUrl`.
+- Edit your `config.json` to include the plug `name`, `deviceURL`, `hardwareVersion`,
+  `channel`, & `authToken`.
 
 If you're setting this plug up fresh, make sure you go through the
 typical meross app for initial setup. You will need to know what the
-plugs IP address is on your network & the channel that plug is running on.
+plugs IP address is on your network. You will also have to get the
+auth token that the meross mobile app uses in its HTTP request headers, 
+the first number of the hardware version (ex. **1**.0.0), & the channel that plug is running on. 
+I used Charles proxy and proxied to my iPhone to sniff the network 
+requests from the app.
+
+Yep, that's probably fragile and all kinds of bad. #YOLO
 
 ``` json
 {
@@ -30,14 +36,18 @@ plugs IP address is on your network & the channel that plug is running on.
     {
       "accessory": "Meross",
       "name": "Bedroom lamp",
+      "deviceUrl": "http://192.168.11.11",
+      "hardwareVersion": 1,
       "channel": 0,
-      "deviceUrl": "http://192.168.11.11"
+      "authToken": "Basic [token you sniffed yourself]"
     },
     {
       "accessory": "Meross",
       "name": "Entertainment center lights",
+      "deviceUrl": "http://192.168.11.12",
+      "hardwareVersion": 2,
       "channel": 0,
-      "deviceUrl": "http://192.168.11.12"
+      "authToken": "Basic [token you sniffed yourself]"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -17,15 +17,16 @@ meross plugin:
 
 - `npm i -g homebridge-meross-plug` (You may need `sudo` depending on
   your homebridge setup)
-- Edit your `config.json` to include the plug `name`, `authToken`, &
-  `deviceUrl`.
+- Edit your `config.json` to include the plug `name`, `deviceURL`, `hardwareVersion`,
+  & `authToken`.
 
 If you're setting this plug up fresh, make sure you go through the
 typical meross app for initial setup. You will need to know what the
 plugs IP address is on your network. You will also have to get the
-auth token that the meross mobile app uses in its HTTP request
-headers. I used Charles proxy and proxied to my iPhone to sniff the
-network requests from the app.
+auth token that the meross mobile app uses in its HTTP request headers 
+as well as the first number of the hardware version (ex. **1**.0.0). 
+I used Charles proxy and proxied to my iPhone to sniff the network 
+requests from the app.
 
 Yep, that's probably fragile and all kinds of bad. #YOLO
 
@@ -36,12 +37,14 @@ Yep, that's probably fragile and all kinds of bad. #YOLO
       "accessory": "Meross",
       "name": "Bedroom lamp",
       "deviceUrl": "http://192.168.11.11",
+      "hardwareVersion": 1,
       "authToken": "Basic [token you sniffed yourself]"
     },
     {
       "accessory": "Meross",
       "name": "Entertainment center lights",
       "deviceUrl": "http://192.168.11.12",
+      "hardwareVersion": 2,
       "authToken": "Basic [token you sniffed yourself]"
     }
   ]

--- a/src/index.js
+++ b/src/index.js
@@ -75,40 +75,85 @@ class MerossPlug {
     this.log(this.config, `${this.config.deviceUrl}/config`)
     let response;
 
-    try {
-      response = await doRequest({
-        method: 'POST',
-        url: `${this.config.deviceUrl}/config`,
-        headers: {
-          "Content-Type": "application/json",
-          "AppVersion": "1.4.0",
-          "Authorization": `${this.config.authToken}`,
-          "vendor":"meross"
-        },
-        json: true,
-        strictSSL: false,
-        body: {
-          "payload": {
-            "togglex": {
-              "onoff": value ? 1 : 0,
-              "channel": 0
-            }
+    /* 
+     * This assumes future versions of MSS110 plugs will adopt the 2.x.x + payload. Easy enough to adapt if neccessary. 
+     * case 1 - Hardware version 1.x.x
+     * default - Hardware version 2.x.x +
+     */
+    switch (this.config.hardwareVersion) {
+      case 1:
+      try {
+        response = await doRequest({
+          method: 'POST',
+          url: `${this.config.deviceUrl}/config`,
+          headers: {
+            "Content-Type": "application/json",
+            "AppVersion": "1.4.0",
+            "Authorization": `${this.config.authToken}`,
+            "vender":"meross"
           },
-          "header": {
-            "messageId": "c3222c7d2b9163fe2968f06c45338a9f",
-            "method": "SET",
-            "from": `http:\/\/${this.config.deviceUrl}\/config`,
-            "namespace": "Appliance.Control.ToggleX",
-            "timestamp": 1543987687,
-            // TODO probably can recycle the 'sign' from the response of this request
-            // in case this gets stale and no longer works. No idea what it does.
-            "sign": "9cb8004faf1ea39e94256227c9fb0b19",
-            "payloadVersion": 1
+          json: true,
+          strictSSL: false,
+          body: {
+            "payload": {
+              "toggle": {
+                "onoff": value ? 1 : 0
+              }
+            },
+            "header": {
+              "messageId": "ea3a20d62868f6c309b6e1b8aeab1ecc",
+              "method": "SET",
+              "from": `${this.config.deviceUrl}/config`,
+              "namespace": "Appliance.Control.Toggle",
+              "timestamp": 1550640048,
+              // TODO probably can recycle the 'sign' from the response of this request
+              // in case this gets stale and no longer works. No idea what it does.
+              "sign": "9430a84459d15a522a9cb91c93f63b45",
+              "payloadVersion": 1
+            }
           }
-        }
-      });
-    } catch (e) {
-      this.log('Failed to POST to the Meross Plug:', e);
+        });
+      } catch (e) {
+        this.log('Failed to POST to the Meross Plug:', e);
+      }
+      break;
+      default:
+      try {
+        response = await doRequest({
+          method: 'POST',
+          url: `${this.config.deviceUrl}/config`,
+          headers: {
+            "Content-Type": "application/json",
+            "AppVersion": "1.4.0",
+            "Authorization": `${this.config.authToken}`,
+            "vender":"meross"
+          },
+          json: true,
+          strictSSL: false,
+          body: {
+            "payload": {
+              "togglex": {
+                "onoff": value ? 1 : 0,
+                "channel" : 0
+              }
+            },
+            "header": {
+              "messageId": "ea3a20d62868f6c309b6e1b8aeab1ecc",
+              "method": "SET",
+              "from": `${this.config.deviceUrl}/config`,
+              "namespace": "Appliance.Control.ToggleX",
+              "timestamp": 1550640048,
+              // TODO probably can recycle the 'sign' from the response of this request
+              // in case this gets stale and no longer works. No idea what it does.
+              "sign": "9430a84459d15a522a9cb91c93f63b45",
+              "payloadVersion": 1
+            }
+          }
+        });
+      } catch (e) {
+        this.log('Failed to POST to the Meross Plug:', e);
+      }
+      break;
     }
 
     if (response) {

--- a/src/index.js
+++ b/src/index.js
@@ -74,23 +74,66 @@ class MerossPlug {
     this.log(this.config, `${this.config.deviceUrl}/config`);
     let response;
 
-    try {
-      response = await doRequest({
+    /* 
+     * This assumes future versions of MSS110 plugs will adopt the 2.x.x + payload. Easy enough to adapt if neccessary. 
+     * case 1 - Hardware version 1.x.x
+     * default - Hardware version 2.x.x +
+     */
+    switch (this.config.hardwareVersion) {
+      case 1:
+      try {
+        response = await doRequest({
         json: true,
         method: "POST",
         strictSSL: false,
         url: `${this.config.deviceUrl}/config`,
         headers: {
           "Content-Type": "application/json"
-        },
-        body: {
-          payload: {
-            togglex: {
-              onoff: value ? 1 : 0,
-              channel: `${this.config.channel}`
-            }
           },
-          header: {
+          body: {
+            "payload": {
+              "toggle": {
+                "onoff": value ? 1 : 0
+              }
+            },
+            "header": {
+              "messageId": "ea3a20d62868f6c309b6e1b8aeab1ecc",
+              "method": "SET",
+              "from": `${this.config.deviceUrl}/config`,
+              "namespace": "Appliance.Control.Toggle",
+              "timestamp": 1550640048,
+              // TODO probably can recycle the 'sign' from the response of this request
+              // in case this gets stale and no longer works. No idea what it does.
+              "sign": "9430a84459d15a522a9cb91c93f63b45",
+              "payloadVersion": 1
+            }
+          }
+        });
+      } catch (e) {
+        this.log('Failed to POST to the Meross Plug:', e);
+      }
+      break;
+      default:
+      try {
+        response = await doRequest({
+          method: 'POST',
+          url: `${this.config.deviceUrl}/config`,
+          headers: {
+            "Content-Type": "application/json",
+            "AppVersion": "1.4.0",
+            "Authorization": `${this.config.authToken}`,
+            "vender":"meross"
+          },
+          json: true,
+          strictSSL: false,
+          body: {
+            "payload": {
+              "togglex": {
+                "onoff": value ? 1 : 0,
+                "channel" : 0
+              }
+            },
+            "header": {
             messageId: "c3222c7d2b9163fe2968f06c45338a9f",
             method: "SET",
             from: `${this.config.deviceUrl}\/config`,
@@ -100,11 +143,13 @@ class MerossPlug {
             // in case this gets stale and no longer works. No idea what it does.
             sign: "9cb8004faf1ea39e94256227c9fb0b19",
             payloadVersion: 1
+            }
           }
-        }
-      });
+        });
     } catch (e) {
       this.log("Failed to POST to the Meross Plug:", e);
+      }
+      break;
     }
 
     if (response) {


### PR DESCRIPTION
Hey!

I implemented some slight changes in order to support 1.x and 2.x hardware versions. This is due to the differences in JSON payloads brought up by @chippoman [here](https://github.com/Robdel12/homebridge-meross-plug/issues/1#issuecomment-451710593) and @kalleboo [here](https://github.com/Robdel12/homebridge-meross-plug/issues/3#issuecomment-449956254). I also updated the documentation to reflect the changes needed in the user's config file.

Not really a fan of the duplicated code in my approach but I haven't worked with JavaScript before so there is probably a much better way to implement this. Although, it should be easy to retrofit for any future changes of the sent payload. This fixes the problems I was having with both hardware versions in my house and should also close issues [1](https://github.com/Robdel12/homebridge-meross-plug/issues/1) and [3](https://github.com/Robdel12/homebridge-meross-plug/issues/3). 

I have not tested these changes with the current [PR](https://github.com/Robdel12/homebridge-meross-plug/pull/5) from @cfgCarl but when that does get merged I would be happy to update the documentation and make sure everything works nicely together! 🙂
